### PR TITLE
fix empty arument issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 const { mount } = require('telegraf');
 
-const regex = /^\/([^@\s]+)@?(?:(\S+)|)\s?([\s\S]*)$/i;
+const regex = /^\/([^@\s]+)@?(?:(\S+)|)\s?([\s\S]+)?$/i;
 
 /* eslint no-param-reassign: ["error", { "props": false }] */
 module.exports = () => mount('text', (ctx, next) => {
-  const parts = regex.exec(ctx.message.text);
+  const parts = regex.exec(ctx.message.text.trim());
   if (!parts) return next();
   const command = {
     text: ctx.message.text,
@@ -12,7 +12,7 @@ module.exports = () => mount('text', (ctx, next) => {
     bot: parts[2],
     args: parts[3],
     get splitArgs() {
-      return parts[3].split(/\s+/);
+      return !parts[3] ? [] : parts[3].split(/\s+/).filter(arg => arg.length);
     },
   };
   ctx.state.command = command;


### PR DESCRIPTION
"/some"
original result: splitArgs.length == 1
expected result: splitArgs.length == 0

"/some var(many spaces after)          var2"
original result: splitArgs.length > 2
expected result: splitArgs.length == 2

1) the original regexp creates 3rd matching group even if it is empty and return an empty string instead of undefined. 
2) in this case String.split creates array with the 1 empty argument
3) String.split also has a bad reaction on spaces between arguments

