### PR TITLE
Update README.md - fix little bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Bot Framework.
 It provides a middleware that splits a command in a Telegram text message to
 its parts. These parts are stored in `ctx.state.command`.
 
-For example, if your text message is `/start@yourbot Hi!`, the
+For example, if your text message is `/start@yourbot Hello world!`, the
 `ctx.state.command` holds the following properties:
 
 - `text` '/start@yourbot Hello world!'


### PR DESCRIPTION
The example mentioned in the 9th line was `/start@yourbot Hi!`, while it seems that the rest of the example (from line 12 to 16) goes with `/start@yourbot Hello world!` as the input text to the bot; So it may cause confusion about the bot functionality.