### PR TITLE
Update for Telegraf v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-const { mount } = require('telegraf');
+const { Telegraf } = require('telegraf');
 
 const regex = /^\/([^@\s]+)@?(?:(\S+)|)\s?([\s\S]+)?$/i;
 
 /* eslint no-param-reassign: ["error", { "props": false }] */
-module.exports = () => mount('text', (ctx, next) => {
+module.exports = () => Telegraf.mount('text', (ctx, next) => {
   const messageText = ctx.updateType === 'channel_post' ? ctx.channelPost.text : ctx.message.text;
   const parts = regex.exec(messageText);
   if (!parts) return next();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telegraf-command-parts",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Command Parts Splitter for Telegraf",
   "main": "index.js",
   "author": "Samuel Kaiser",
@@ -21,6 +21,6 @@
     "telegram"
   ],
   "dependencies": {
-    "telegraf": "^3.1.0"
+    "telegraf": "^3.1.0 || ^4.0.0"
   }
 }


### PR DESCRIPTION
Telegraf v4 does not export the `mount` function directly anymore.

I tested this change against Telegraf 3.38.0 and 4.0.3.

If possible, please double check if it works for you with Telegraf v3.